### PR TITLE
Bluewin improvements

### DIFF
--- a/client/build/tasks/serve.js
+++ b/client/build/tasks/serve.js
@@ -1,5 +1,5 @@
-var gulp = require('gulp');
-var browserSync = require('browser-sync');
+let gulp = require('gulp');
+let browserSync = require('browser-sync');
 
 // this task utilizes the browsersync plugin
 // to create a dev server instance
@@ -11,7 +11,7 @@ gulp.task('serve', ['build'], function(done) {
     open: false,
     port: require('../../../config').port,
     ui: {
-      port: require('../../../config').port + 1
+      port: require('../../../config').port - 1
     },
     server: {
       baseDir: ['.'],

--- a/client/build/tasks/serve.js
+++ b/client/build/tasks/serve.js
@@ -1,5 +1,5 @@
-let gulp = require('gulp');
-let browserSync = require('browser-sync');
+const gulp = require('gulp');
+const browserSync = require('browser-sync');
 
 // this task utilizes the browsersync plugin
 // to create a dev server instance

--- a/client/build/tasks/watch.js
+++ b/client/build/tasks/watch.js
@@ -1,6 +1,6 @@
-var gulp = require('gulp');
-var paths = require('../paths');
-var browserSync = require('browser-sync');
+const gulp = require('gulp');
+const paths = require('../paths');
+const browserSync = require('browser-sync');
 
 // outputs changes to files to the console
 function reportChange(event) {
@@ -12,12 +12,12 @@ function reportChange(event) {
 // reportChange method. Also, by depending on the
 // serve task, it will instantiate a browserSync session
 gulp.task('watch', ['serve'], function() {
-  gulp.watch(paths.source, ['build-system', browserSync.reload]).on('change', reportChange);
-  gulp.watch(paths.html, ['build-html', browserSync.reload]).on('change', reportChange);
+  gulp.watch(paths.source, ['build-system']).on('change', reportChange);
+  gulp.watch(paths.html, ['build-html']).on('change', reportChange);
   gulp.watch(paths.sass, ['build-sass']).on('change', reportChange);
-  gulp.watch(paths.css, ['build-css']).on('change', reportChange);
-  gulp.watch(paths.style, function() {
-    return gulp.src(paths.style)
-      .pipe(browserSync.stream());
-  }).on('change', reportChange);
+  // gulp.watch(paths.css, ['build-css']).on('change', reportChange);
+  gulp.watch(paths.css, ['build-css', function() {
+    return gulp.src(paths.css).pipe(browserSync.stream());
+  }
+  ]).on('change', reportChange);
 });

--- a/client/config.js
+++ b/client/config.js
@@ -48,6 +48,7 @@ System.config({
     "heyman/leaflet-areaselect": "github:heyman/leaflet-areaselect@master",
     "i18next": "npm:i18next@9.1.0",
     "i18next-fetch-backend": "npm:i18next-fetch-backend@0.0.1",
+    "i18next-xhr-backend": "npm:i18next-xhr-backend@3.2.2",
     "leaflet": "github:Leaflet/Leaflet@1.3.1",
     "leaflet-geocoder-mapzen": "npm:leaflet-geocoder-mapzen@1.8.0",
     "leaflet-search": "npm:leaflet-search@2.3.7",
@@ -97,6 +98,9 @@ System.config({
     },
     "github:jspm/nodelibs-vm@0.1.0": {
       "vm-browserify": "npm:vm-browserify@0.0.4"
+    },
+    "npm:@babel/runtime@7.7.6": {
+      "regenerator-runtime": "npm:regenerator-runtime@0.13.3"
     },
     "npm:ajv@5.5.2": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.1",
@@ -481,6 +485,9 @@ System.config({
     "npm:i18next-fetch-backend@0.0.1": {
       "i18next-xhr-backend": "npm:i18next-xhr-backend@1.5.1"
     },
+    "npm:i18next-xhr-backend@3.2.2": {
+      "@babel/runtime": "npm:@babel/runtime@7.7.6"
+    },
     "npm:i18next@9.1.0": {
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
@@ -589,6 +596,9 @@ System.config({
       "process": "github:jspm/nodelibs-process@0.1.2",
       "stream-browserify": "npm:stream-browserify@1.0.0",
       "string_decoder": "npm:string_decoder@0.10.31"
+    },
+    "npm:regenerator-runtime@0.13.3": {
+      "path": "github:jspm/nodelibs-path@0.1.0"
     },
     "npm:ripemd160@2.0.2": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.1",

--- a/client/env
+++ b/client/env
@@ -1,5 +1,5 @@
 {
-  "QServerBaseUrl": "http://localhost:9050",
+  "QServerBaseUrl": "https://localhost:9000/proxy/q-server",
   "SophieBuildService": "https://sophieservicestage-2cac.kxcdn.com/bundle/",
   "loginMessage": "login message",
   "devLogging": true,

--- a/client/index.html
+++ b/client/index.html
@@ -1,31 +1,37 @@
 <!DOCTYPE html>
 <html>
+
   <head>
     <meta name="charset" content="utf-8">
     <title>Q</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/favicon.png">
-    <base href="/">
+    <base href="https://localhost:9000/proxy/q-editor/">
     <!-- HEAD_MARKUP -->
   </head>
+
   <body aurelia-app="main">
     <!-- BODY_START_MARKUP -->
     <div style="position: absolute; top: calc(50% - 20vh); left: calc(50% - 15vh); width: 30vh; width: 30vh;">
       <svg viewBox="0 0 172 172">
-        <path d="M63.9,22.7l7.7-2.2c0,0,34.3-9.8,55.6,18.3c20.9,27.6,17,73.4-3.6,91.4c1.5,2.4,6,13,17.9,12.4c-10.8,4.7-21.4,4.3-28.2-9.4c0,0,20.3-15.7,17-53.5c-2.8-31.7-18.3-48.2-36.9-54.8C78.8,20.2,67.8,22.2,63.9,22.7z M130.4,161.4l10.2-3c9.1-3.5,15.4-14,19.2-23.4l-10.2,3C147.4,144.1,140.1,158.1,130.4,161.4z M48.7,70.1c-1.1,20.4,1.6,35.7,5.6,43.8l1.3,1.2c0,0,6.5-9,6-12.2c-3.1-11.9-4-29.2-1.5-43.5c2.4-13.6,9.2-24,15.7-27.1C61.3,33,49.9,48.1,48.7,70.1z M70.8,97.3c1.1-0.2,5.5-0.9,11.1,0.5c8.9,2.3,16.5,10.7,22.5,21c2.6-1.8,4.9-10.7,3.5-12.6c-1.4-1.9-5.9-8-13.6-10.8c-7.8-2.8-14.1-1-14.1-1L70.8,97.3z M81.1,131.6c6,0.6,11.5-1.1,13.7-2.8c-1.9,0.2-6.6-0.1-12.1-1.7c-5.2-1.5-9.2-4.6-11.1-6.6c0.3-8.3,4.6-11.7,6.3-12.4c-2.2,0.1-8.3,0.2-12.6,4.6c-4,4.1-3.9,10.9-3.9,10.9C67.6,129.6,73.9,131,81.1,131.6z"/>
-        <path d="M126.9,147c-0.4,0-0.7-0.1-1.1-0.1c-6.4-0.7-10.8-4.5-15.9-13.1c11.7-10.4,17.7-27.2,17.6-47.1c-0.3-16.9-4.9-32.4-13.4-43.4C105.5,32.1,93.2,25,77.9,23.7C43,20.8,27.7,46.2,28,80.2c0.4,36.4,22.1,60.4,49.5,62.7c7.8,0.7,14.6-0.2,21.4-2.7c6,11.6,12.6,20.7,23.5,21.6c9.8,0.8,18.4-9.9,22.8-20.5C138.5,145.8,134.5,147.6,126.9,147z M77.9,133.3c-8.3-0.7-14.7-3.8-19.7-8.6c0.1-10.1,6.3-16.7,14.9-16c10.7,0.9,15.5,11.1,20.7,21.5C89,132.9,84.1,134,77.9,133.3z M102.5,121.7c-8.3-13-15.1-21.9-27.4-22.9c-11.3-0.9-18.8,5.3-22.3,19.3c-5.9-11.7-7.4-24.3-7.6-37.1c-0.3-24.9,6.3-50.2,32.6-48c25.4,2.1,31.6,28,31.8,52.6C109.7,98.7,108.2,111.4,102.5,121.7z"/>
+        <path
+          d="M63.9,22.7l7.7-2.2c0,0,34.3-9.8,55.6,18.3c20.9,27.6,17,73.4-3.6,91.4c1.5,2.4,6,13,17.9,12.4c-10.8,4.7-21.4,4.3-28.2-9.4c0,0,20.3-15.7,17-53.5c-2.8-31.7-18.3-48.2-36.9-54.8C78.8,20.2,67.8,22.2,63.9,22.7z M130.4,161.4l10.2-3c9.1-3.5,15.4-14,19.2-23.4l-10.2,3C147.4,144.1,140.1,158.1,130.4,161.4z M48.7,70.1c-1.1,20.4,1.6,35.7,5.6,43.8l1.3,1.2c0,0,6.5-9,6-12.2c-3.1-11.9-4-29.2-1.5-43.5c2.4-13.6,9.2-24,15.7-27.1C61.3,33,49.9,48.1,48.7,70.1z M70.8,97.3c1.1-0.2,5.5-0.9,11.1,0.5c8.9,2.3,16.5,10.7,22.5,21c2.6-1.8,4.9-10.7,3.5-12.6c-1.4-1.9-5.9-8-13.6-10.8c-7.8-2.8-14.1-1-14.1-1L70.8,97.3z M81.1,131.6c6,0.6,11.5-1.1,13.7-2.8c-1.9,0.2-6.6-0.1-12.1-1.7c-5.2-1.5-9.2-4.6-11.1-6.6c0.3-8.3,4.6-11.7,6.3-12.4c-2.2,0.1-8.3,0.2-12.6,4.6c-4,4.1-3.9,10.9-3.9,10.9C67.6,129.6,73.9,131,81.1,131.6z" />
+        <path
+          d="M126.9,147c-0.4,0-0.7-0.1-1.1-0.1c-6.4-0.7-10.8-4.5-15.9-13.1c11.7-10.4,17.7-27.2,17.6-47.1c-0.3-16.9-4.9-32.4-13.4-43.4C105.5,32.1,93.2,25,77.9,23.7C43,20.8,27.7,46.2,28,80.2c0.4,36.4,22.1,60.4,49.5,62.7c7.8,0.7,14.6-0.2,21.4-2.7c6,11.6,12.6,20.7,23.5,21.6c9.8,0.8,18.4-9.9,22.8-20.5C138.5,145.8,134.5,147.6,126.9,147z M77.9,133.3c-8.3-0.7-14.7-3.8-19.7-8.6c0.1-10.1,6.3-16.7,14.9-16c10.7,0.9,15.5,11.1,20.7,21.5C89,132.9,84.1,134,77.9,133.3z M102.5,121.7c-8.3-13-15.1-21.9-27.4-22.9c-11.3-0.9-18.8,5.3-22.3,19.3c-5.9-11.7-7.4-24.3-7.6-37.1c-0.3-24.9,6.3-50.2,32.6-48c25.4,2.1,31.6,28,31.8,52.6C109.7,98.7,108.2,111.4,102.5,121.7z" />
       </svg>
-      <img style="display: block; margin: 0 auto;" src="data:image/gif;base64,R0lGODlhEAALAPQAAP///xcTE93c3NTT0+vr6xwYGBcTE0A9PY2Li25ra8C/vzUyMlpXV5SSknFvb8PCwjk2NhoWFl1bW+jn59va2vT09ElGRt/e3vPy8ry7u6inp87Nze/v7wAAAAAAAAAAACH/C05FVFNDQVBFMi4wAwEAAAAh/hpDcmVhdGVkIHdpdGggYWpheGxvYWQuaW5mbwAh+QQJCwAAACwAAAAAEAALAAAFLSAgjmRpnqSgCuLKAq5AEIM4zDVw03ve27ifDgfkEYe04kDIDC5zrtYKRa2WQgAh+QQJCwAAACwAAAAAEAALAAAFJGBhGAVgnqhpHIeRvsDawqns0qeN5+y967tYLyicBYE7EYkYAgAh+QQJCwAAACwAAAAAEAALAAAFNiAgjothLOOIJAkiGgxjpGKiKMkbz7SN6zIawJcDwIK9W/HISxGBzdHTuBNOmcJVCyoUlk7CEAAh+QQJCwAAACwAAAAAEAALAAAFNSAgjqQIRRFUAo3jNGIkSdHqPI8Tz3V55zuaDacDyIQ+YrBH+hWPzJFzOQQaeavWi7oqnVIhACH5BAkLAAAALAAAAAAQAAsAAAUyICCOZGme1rJY5kRRk7hI0mJSVUXJtF3iOl7tltsBZsNfUegjAY3I5sgFY55KqdX1GgIAIfkECQsAAAAsAAAAABAACwAABTcgII5kaZ4kcV2EqLJipmnZhWGXaOOitm2aXQ4g7P2Ct2ER4AMul00kj5g0Al8tADY2y6C+4FIIACH5BAkLAAAALAAAAAAQAAsAAAUvICCOZGme5ERRk6iy7qpyHCVStA3gNa/7txxwlwv2isSacYUc+l4tADQGQ1mvpBAAIfkECQsAAAAsAAAAABAACwAABS8gII5kaZ7kRFGTqLLuqnIcJVK0DeA1r/u3HHCXC/aKxJpxhRz6Xi0ANAZDWa+kEAA7AAAAAAAAAAAA"/>
+      <img style="display: block; margin: 0 auto;"
+        src="data:image/gif;base64,R0lGODlhEAALAPQAAP///xcTE93c3NTT0+vr6xwYGBcTE0A9PY2Li25ra8C/vzUyMlpXV5SSknFvb8PCwjk2NhoWFl1bW+jn59va2vT09ElGRt/e3vPy8ry7u6inp87Nze/v7wAAAAAAAAAAACH/C05FVFNDQVBFMi4wAwEAAAAh/hpDcmVhdGVkIHdpdGggYWpheGxvYWQuaW5mbwAh+QQJCwAAACwAAAAAEAALAAAFLSAgjmRpnqSgCuLKAq5AEIM4zDVw03ve27ifDgfkEYe04kDIDC5zrtYKRa2WQgAh+QQJCwAAACwAAAAAEAALAAAFJGBhGAVgnqhpHIeRvsDawqns0qeN5+y967tYLyicBYE7EYkYAgAh+QQJCwAAACwAAAAAEAALAAAFNiAgjothLOOIJAkiGgxjpGKiKMkbz7SN6zIawJcDwIK9W/HISxGBzdHTuBNOmcJVCyoUlk7CEAAh+QQJCwAAACwAAAAAEAALAAAFNSAgjqQIRRFUAo3jNGIkSdHqPI8Tz3V55zuaDacDyIQ+YrBH+hWPzJFzOQQaeavWi7oqnVIhACH5BAkLAAAALAAAAAAQAAsAAAUyICCOZGme1rJY5kRRk7hI0mJSVUXJtF3iOl7tltsBZsNfUegjAY3I5sgFY55KqdX1GgIAIfkECQsAAAAsAAAAABAACwAABTcgII5kaZ4kcV2EqLJipmnZhWGXaOOitm2aXQ4g7P2Ct2ER4AMul00kj5g0Al8tADY2y6C+4FIIACH5BAkLAAAALAAAAAAQAAsAAAUvICCOZGme5ERRk6iy7qpyHCVStA3gNa/7txxwlwv2isSacYUc+l4tADQGQ1mvpBAAIfkECQsAAAAsAAAAABAACwAABS8gII5kaZ7kRFGTqLLuqnIcJVK0DeA1r/u3HHCXC/aKxJpxhRz6Xi0ANAZDWa+kEAA7AAAAAAAAAAAA" />
       <p style="color: red" id="q-load-error-message"></p>
     </div>
     <script src="jspm_packages/system.js"></script>
     <script src="config.js"></script>
     <script>
       System.import('aurelia-bootstrapper');
-      window.QLoadErrorTimeout = setTimeout(function() {
+      window.QLoadErrorTimeout = setTimeout(function () {
         document.getElementById('q-load-error-message').insertAdjacentHTML('beforeend', 'This is taking way too long, are you using the latest version of your browser?')
       }, 3000)
     </script>
     <!-- BODY_END_MARKUP -->
   </body>
+
 </html>

--- a/client/package.json
+++ b/client/package.json
@@ -77,6 +77,7 @@
       "heyman/leaflet-areaselect": "github:heyman/leaflet-areaselect@master",
       "i18next": "npm:i18next@9",
       "i18next-fetch-backend": "npm:i18next-fetch-backend@^0.0.1",
+      "i18next-xhr-backend": "npm:i18next-xhr-backend@^3.2.2",
       "leaflet": "github:Leaflet/Leaflet@1.3.1",
       "leaflet-geocoder-mapzen": "npm:leaflet-geocoder-mapzen@1.8.0",
       "leaflet-search": "npm:leaflet-search@2.3.7",

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -25,8 +25,8 @@ export class App {
   configureRouter(config, router) {
     this.router = router;
     config.title = "Q";
-    config.addPreActivateStep(ConfigAvailableCheckStep);
     config.addAuthorizeStep(AuthorizeStep); // Add a route filter to the authorize extensibility point.
+    config.addPreActivateStep(ConfigAvailableCheckStep);
     config.addPipelineStep("postcomplete", ScrollToTopStep);
 
     let routerMap = [

--- a/client/src/elements/item-preview/item-preview.css
+++ b/client/src/elements/item-preview/item-preview.css
@@ -37,6 +37,8 @@ item-preview {
   display: flex;
   height: 100%;
   overflow: auto;
+  padding: var(--q-preview-padding);
+  margin-right: calc(var(--q-space-base) * 2);
 }
 
 .item-preview__notification {

--- a/client/src/elements/item-preview/item-preview.html
+++ b/client/src/elements/item-preview/item-preview.html
@@ -3,16 +3,18 @@
   <require from="./item-preview.css"></require>
   <require from="../molecules/radio-button-group"></require>
   <div class="item-preview__holder">
-    <form class="item-preview__settings" if.bind="initialised">
+    <form class="item-preview__settings" if.bind="initialised && sizeOptions.length > 1">
       <div>
         <label class="q-text-small q-text--light">${'preview.sizeLabel' & t}</label>
-        <radio-button-group options.bind="sizeOptions" value.two-way="previewWidthProxy.width | forceNumber"></radio-button-group>
+        <radio-button-group options.bind="sizeOptions" value.two-way="previewWidthProxy.width | forceNumber">
+        </radio-button-group>
       </div>
     </form>
     <div class="item-preview__container">
-      <preview-container ref="previewContainer" width.one-way="previewWidthProxy.width" rendering-info.one-way="renderingInfo"
+      <preview-container ref="previewContainer" width.one-way="previewWidthProxy.width"
+        scale-to-fit.one-way="previewWidthProxy.scaleToFit" rendering-info.one-way="renderingInfo"
         target.one-way="targetProxy.target" error.bind="error" loading-status.bind="loadingStatus"></preview-container>
-      <div class="item-preview__notification">
+      <div class="item-preview__notification" if.bind="notification">
         <notification notification.bind="notification"></notification>
         <!-- this is used to show the notifications from options -->
         <slot name="notifications"></slot>

--- a/client/src/elements/item-preview/preview-container.css
+++ b/client/src/elements/item-preview/preview-container.css
@@ -3,6 +3,5 @@ preview-container {
   display: block;
   overflow: auto;
   width: 100%;
-  margin-right: calc(var(--q-space-base) * 2);
   border: solid 1px var(--q-color-gray-4);
 }

--- a/client/src/elements/item-preview/preview-container.html
+++ b/client/src/elements/item-preview/preview-container.html
@@ -14,9 +14,13 @@
 
     .preview-element {
       margin: auto;
-      min-height: calc(var(--q-preview-min-height) + 2 * var(--q-preview-padding) - 2px); /* minus 2px because of the border of the container */
+      min-height: calc(var(--q-preview-min-height) + 2 * var(--q-preview-padding) - 2px);
+      /* minus 2px because of the border of the container */
       box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.15);
-      padding: var(--q-preview-padding);
+    }
+
+    .preview-holder {
+      overflow: hidden;
     }
 
     .preview-element__error-box {
@@ -34,12 +38,17 @@
     .preview-element__error-text {
       font-weight: normal;
     }
+
   </style>
-  <div class="preview-element-container">
-    <div class="preview-element" css="width: calc(${width}px + (2 * var(--q-preview-padding))); color: ${previewColor}; background-color: ${previewColor};">
-      <div ref="previewElement" css="overflow: hidden; ${loadingStatus === 'loading' ? 'opacity: 0' : 'opacity: 1'};"></div>
+  <div class="preview-element-container"
+    css="max-width: 100%; width: calc(${cssWidth} + (2 * var(--q-preview-padding))); color: ${previewColor}; background-color: ${previewColor};">
+    <div class="preview-element">
+      <div ref="previewHolder" class="preview-holder"
+        css="${loadingStatus === 'loading' || applyingScaleToFit ? 'opacity: 0' : 'opacity: 1'};">
+      </div>
       <div class="preview-element__error-box" show.bind="error">
-        <h4 class="preview-element__error-text">${'preview.generalError.title' & t} ${'preview.generalError.body' & t}</h4>
+        <h4 class="preview-element__error-text">${'preview.generalError.title' & t} ${'preview.generalError.body' & t}
+        </h4>
       </div>
     </div>
   </div>

--- a/client/src/elements/item-preview/preview-container.js
+++ b/client/src/elements/item-preview/preview-container.js
@@ -37,11 +37,11 @@ export class PreviewContainer {
     if (!width) {
       return;
     }
-    if (Number.isNaN(parseFloat(width))) {
+    if (Number.isNaN(Number(width))) {
       if (width === 'auto') {
         this.cssWidth = '100%';
-      } else if (width.endsWith('%')) {
-        this.cssWidth = width;
+      } else {
+        throw new Error(`Unsupported width value '${width}'`);
       }
     } else {
       this.cssWidth = `${width}px`;

--- a/client/src/elements/molecules/item-list-entry.html
+++ b/client/src/elements/molecules/item-list-entry.html
@@ -1,17 +1,21 @@
 <template containerless>
   <a route-href="route: item; params.bind: {id: item.id}">
     <require from="./item-list-entry.css"></require>
-    <span if.bind="item.conf.active" class="q-text-small item-list-entry__state-tag item-list-entry__state-tag--active">${'item.active' & t}</span>
-    <span if.bind="!item.conf.active" class="q-text-small item-list-entry__state-tag item-list-entry__state-tag--inactive">${'item.inactive' & t}</span>
+    <span if.bind="item.conf.active"
+      class="q-text-small item-list-entry__state-tag item-list-entry__state-tag--active">${'item.active' & t}</span>
+    <span if.bind="!item.conf.active"
+      class="q-text-small item-list-entry__state-tag item-list-entry__state-tag--inactive">${'item.inactive' & t}</span>
     <box-icon if.bind="iconSvg" code.bind="iconSvg" size="big" class="tool-icon"></box-icon>
 
     <span class="q-text-small">${item.conf.title}</span>
-    <span class="q-text-small">${item.conf.createdBy}</span>
+    <span class="q-text-small" if.bind="!hideEditUserName">${item.conf.createdBy}</span>
     <span class="q-text-small" if.bind="item.conf.updatedDate">
-      ${'general.edited' & t} ${item.conf.updatedDate & timeAgo:7*24*60*60}, ${'general.by' & t} ${item.conf.updatedBy}
+      ${'general.edited' & t} ${item.conf.updatedDate & timeAgo:7*24*60*60}<span if.bind="!hideEditUserName">,
+        ${'general.by' & t} ${item.conf.updatedBy}</span>
     </span>
     <span class="q-text-small" if.bind="!item.conf.updatedDate">
-      ${'general.edited' & t} ${item.conf.createdDate & timeAgo:7*24*60*60}, ${'general.by' & t} ${item.conf.createdBy}
+      ${'general.edited' & t} ${item.conf.createdDate & timeAgo:7*24*60*60}<span if.bind="!hideEditUserName">,
+        ${'general.by' & t} ${item.conf.createdBy}</span>
     </span>
   </a>
   <dropdown-menu>
@@ -19,6 +23,7 @@
     <a if.bind="!item.conf.active" click.delegate="itemActionController.activate(item)">${'item.activate' & t }</a>
     <a if.bind="item.conf.active" click.delegate="itemActionController.deactivate(item)">${'item.deactivate' & t }</a>
     <a click.delegate="itemActionController.blueprint(item)">${'item.blueprint' & t}</a>
-    <a if.bind="user.roles.includes('poweruser') || user.username === item.conf.createdBy" size="small" click.delegate="deleteItem()">${'item.delete' & t}</a>
+    <a if.bind="user.roles.includes('poweruser') || user.username === item.conf.createdBy" size="small"
+      click.delegate="deleteItem()">${'item.delete' & t}</a>
   </dropdown-menu>
 </template>

--- a/client/src/elements/molecules/item-list-entry.js
+++ b/client/src/elements/molecules/item-list-entry.js
@@ -5,6 +5,7 @@ import ItemActionController from "resources/ItemActionController";
 @inject(ToolsInfo, Element, User, ItemActionController)
 export class ItemListEntry {
   @bindable item;
+  @bindable hideEditUserName;
 
   constructor(toolsInfo, element, user, itemActionController) {
     this.toolsInfo = toolsInfo;

--- a/client/src/elements/organisms/items-list.html
+++ b/client/src/elements/organisms/items-list.html
@@ -1,10 +1,11 @@
-<template bindable="items">
+<template bindable="items, hideCreatedBy">
   <require from="./items-list.css"></require>
   <require from="../molecules/item-list-entry.js"></require>
   <div show.bind="items.length > 0" class="items-list__header q-text-small">
     <span>${'itemsList.title' & t}</span>
-    <span>${'itemsList.author' & t}</span>
+    <span if.bind="!hideEditUserName">${'itemsList.author' & t}</span>
     <span>${'itemsList.updated' & t}</span>
   </div>
-  <item-list-entry show.bind="items.length > 0" repeat.for="item of items" item.bind="item"></item-list-entry>
+  <item-list-entry show.bind="items.length > 0" repeat.for="item of items" item.bind="item"
+    hide-edit-user-name.one-way="hideEditUserName"></item-list-entry>
 </template>

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -1,11 +1,10 @@
 // clear the load error timeout
 window.clearTimeout(window.QLoadErrorTimeout);
 
-import { LogManager, Loader } from "aurelia-framework";
+import { LogManager } from "aurelia-framework";
 import { ConsoleAppender } from "aurelia-logging-console";
 import { Authentication, FetchConfig } from 'aurelia-authentication';
 
-// import { Backend } from "aurelia-i18n";
 import Backend from 'i18next-xhr-backend';
 
 import QConfig from "resources/QConfig.js";
@@ -49,13 +48,8 @@ export async function configure(aurelia) {
   const token = tokenFromStorage && `${tokenFromStorage.replace(/(^"|"$)/g, '')}`;
 
   if (token) localStorage.setItem('aurelia_authentication', JSON.stringify({access_token: token}));
-  // configure the aurelia-fetch-client interceptor to add the auth token to every request
-  // const loader = aurelia.container.get(Loader);
-  // const AureliaAuthentication = await loader.loadModule(
-  //   "aurelia-authentication"
-  // );
 
-  // const FetchConfig = AureliaAuthentication.FetchConfig;
+  // configure the aurelia-fetch-client interceptor to add the auth token to every request
   const fetchConfig = aurelia.container.get(FetchConfig);
   fetchConfig.configure();
   aurelia.use.plugin("aurelia-authentication", baseConfig => {
@@ -85,7 +79,6 @@ export async function configure(aurelia) {
     })
     .plugin("aurelia-i18n", async instance => {
       // register backend plugin
-      // instance.i18next.use(Backend.with(aurelia.loader));
       instance.i18next.use(Backend);
 
       let availableLanguages = ["de", "en"];

--- a/client/src/pages/index.html
+++ b/client/src/pages/index.html
@@ -5,7 +5,7 @@
     <icon-logo class="index__logo" if.bind="enoughNewItems" slot="logo" click.delegate="reloadItems()"></icon-logo>
     <icon-m class="index__logo" if.bind="!enoughNewItems" slot="logo" click.delegate="reloadItems()"></icon-m>
     <language-switcher slot="language-switcher"></language-switcher>
-    <button-secondary slot="account-button" if.bind="user.isLoggedIn && showUserMenu"
+    <button-secondary slot="account-button" if.bind="user.isLoggedIn && uiBehaviorConfig.userMenu !== false"
       click.delegate="showAccountModal()">${user.data.initials}</button-secondary>
   </q-bar>
   <main class="index">
@@ -27,7 +27,8 @@
 
     <items-filter filters.bind="availableFilters" change.call="filterChanged()"></items-filter>
 
-    <items-list items.bind="items" ref="itemsListElement"></items-list>
+    <items-list items.bind="items" hide-edit-user-name.bind="uiBehaviorConfig.hideEditUserName" ref="itemsListElement">
+    </items-list>
     <div class="infitite-scrolling-sentinel" ref="infiniteScrollingSentinel"></div>
     <div class="index__empty-list-message" if.bind="items.length === 0 && !itemsLoading">
       <h4>${'itemsList.empty' & t}</h4>

--- a/client/src/pages/index.html
+++ b/client/src/pages/index.html
@@ -35,10 +35,9 @@
     </div>
     <q-loader if.bind="itemsLoading"></q-loader>
 
-    <div class="index__statistics q-text-small q-text--ultralight" click.delegate="scrollToTop()">
-      <span if.bind="!enoughNewItems && statsValues" t="statistics.tooFewNewGraphics"
-        t-params.bind="statsValues"></span>
-      <span if.bind="enoughNewItems && statsValues" t="statistics.enoughNewGraphics" t-params.bind="statsValues"></span>
+    <div class="index__statistics q-text-small q-text--ultralight" click.delegate="scrollToTop()" if.bind="statsValues">
+      <span if.bind="!enoughNewItems" t="statistics.tooFewNewGraphics" t-params.bind="statsValues"></span>
+      <span if.bind="enoughNewItems" t="statistics.enoughNewGraphics" t-params.bind="statsValues"></span>
     </div>
 
   </main>

--- a/client/src/pages/index.html
+++ b/client/src/pages/index.html
@@ -5,7 +5,8 @@
     <icon-logo class="index__logo" if.bind="enoughNewItems" slot="logo" click.delegate="reloadItems()"></icon-logo>
     <icon-m class="index__logo" if.bind="!enoughNewItems" slot="logo" click.delegate="reloadItems()"></icon-m>
     <language-switcher slot="language-switcher"></language-switcher>
-    <button-secondary slot="account-button" if.bind="user.isLoggedIn" click.delegate="showAccountModal()">${user.data.initials}</button-secondary>
+    <button-secondary slot="account-button" if.bind="user.isLoggedIn && showUserMenu"
+      click.delegate="showAccountModal()">${user.data.initials}</button-secondary>
   </q-bar>
   <main class="index">
     <tool-selection>
@@ -14,9 +15,11 @@
     <h2>${'general.searchEditLabel' & t}</h2>
     <div>
       <div class="search">
-        <input t="[placeholder]general.searchLabel" input.delegate="filterChanged() & debounce" value.two-way="currentSearchString">
+        <input t="[placeholder]general.searchLabel" input.delegate="filterChanged() & debounce"
+          value.two-way="currentSearchString">
         <svg viewBox="0 0 34 32" xmlns="http://www.w3.org/2000/svg">
-          <path d="M22.5 21.23a9.73 9.73 0 1 1 0-19.46c5.374 0 9.73 4.356 9.73 9.73 0 5.374-4.356 9.73-9.73 9.73zM13.782 19A11.455 11.455 0 0 1 11 11.5C11 5.149 16.149 0 22.5 0S34 5.149 34 11.5 28.851 23 22.5 23a11.455 11.455 0 0 1-7.5-2.782v2.496l-9.71 8.014c-.853.705-2.175.643-2.958-.132l-.914-.906c-.782-.774-.728-1.974.123-2.676L11.25 19h2.532z"
+          <path
+            d="M22.5 21.23a9.73 9.73 0 1 1 0-19.46c5.374 0 9.73 4.356 9.73 9.73 0 5.374-4.356 9.73-9.73 9.73zM13.782 19A11.455 11.455 0 0 1 11 11.5C11 5.149 16.149 0 22.5 0S34 5.149 34 11.5 28.851 23 22.5 23a11.455 11.455 0 0 1-7.5-2.782v2.496l-9.71 8.014c-.853.705-2.175.643-2.958-.132l-.914-.906c-.782-.774-.728-1.974.123-2.676L11.25 19h2.532z"
             fill-rule="evenodd" />
         </svg>
       </div>
@@ -32,7 +35,8 @@
     <q-loader if.bind="itemsLoading"></q-loader>
 
     <div class="index__statistics q-text-small q-text--ultralight" click.delegate="scrollToTop()">
-      <span if.bind="!enoughNewItems && statsValues" t="statistics.tooFewNewGraphics" t-params.bind="statsValues"></span>
+      <span if.bind="!enoughNewItems && statsValues" t="statistics.tooFewNewGraphics"
+        t-params.bind="statsValues"></span>
       <span if.bind="enoughNewItems && statsValues" t="statistics.enoughNewGraphics" t-params.bind="statsValues"></span>
     </div>
 

--- a/client/src/pages/index.js
+++ b/client/src/pages/index.js
@@ -50,9 +50,7 @@ export class Index {
   }
 
   async activate() {
-    const uiBehaviorConfig = await this.qConfig.get('uiBehavior');
-    // the default is to show the user menu, only if it is disabled, we hide it
-    this.showUserMenu = uiBehaviorConfig.userMenu === false ? false : true;
+    this.uiBehaviorConfig = await this.qConfig.get('uiBehavior');
   }
 
   async attached() {

--- a/client/src/pages/index.js
+++ b/client/src/pages/index.js
@@ -49,6 +49,12 @@ export class Index {
     return this.user.loaded;
   }
 
+  async activate() {
+    const uiBehaviorConfig = await this.qConfig.get('uiBehavior');
+    // the default is to show the user menu, only if it is disabled, we hide it
+    this.showUserMenu = uiBehaviorConfig.userMenu === false ? false : true;
+  }
+
   async attached() {
     if (!this.initialised) {
       this.applyUserDefinedFilters();

--- a/client/src/pages/item-overview.html
+++ b/client/src/pages/item-overview.html
@@ -16,7 +16,8 @@
           <label class="q-text-small q-text--light">${ 'general.articlesWithThisGraphic' & t }</label>
           <ul>
             <li repeat.for="article of articlesWithItem">
-              <a class="q-text" target="_blank" rel="noopener" href="${article.url}">${article.title} (${article.publicationLastUpdated | timeAgo})</a>
+              <a class="q-text" target="_blank" rel="noopener" href="${article.url}">${article.title}
+                (${article.publicationLastUpdated | timeAgo})</a>
             </li>
           </ul>
         </div>
@@ -25,26 +26,31 @@
         <div class="item-overview__status q-text-small q-text--light">
           <icon-active-state class="tool-status-bar__item" is-active.bind="item.conf.active"></icon-active-state>
           <div>${ 'general.created' & t } ${ item.conf.createdDate & timeAgo:7*24*60*60 }
-            <br> ${ 'general.by' & t } ${item.conf.createdBy}</div>
+            <br> <span if.bind="uiBehaviorConfig.hideCreatedBy">${ 'general.by' & t } ${item.conf.createdBy}</span>
+          </div>
           <div if.bind="item.conf.updatedDate">${ 'general.edited' & t } ${ item.conf.updatedDate & timeAgo:7*24*60*60 }
-            <br> ${ 'general.by' & t } ${item.conf.updatedBy}</div>
+            <br> <span if.bind="uiBehaviorConfig.hideCreatedBy">${ 'general.by' & t } ${item.conf.updatedBy}</span>
+          </div>
         </div>
 
         <button-secondary if.bind="isToolAvailable" click.delegate="itemActionController.edit(item)" icon="edit">
           <span t="item.edit"></span>
         </button-secondary>
 
-        <button-secondary if.bind="!item.conf.active" click.delegate="itemActionController.activate(item)" icon="activate">
+        <button-secondary if.bind="!item.conf.active" click.delegate="itemActionController.activate(item)"
+          icon="activate">
           <span t="item.activate"></span>
         </button-secondary>
 
-        <button-secondary if.bind="item.conf.active" click.delegate="itemActionController.deactivate(item)" icon="deactivate">
+        <button-secondary if.bind="item.conf.active" click.delegate="itemActionController.deactivate(item)"
+          icon="deactivate">
           <span t="item.deactivate"></span>
         </button-secondary>
 
         <embed-code item.bind="item" target.bind="currentTarget"></embed-code>
 
-        <button-secondary if.bind="isToolAvailable" click.delegate="itemActionController.blueprint(item)" icon="blueprint">
+        <button-secondary if.bind="isToolAvailable" click.delegate="itemActionController.blueprint(item)"
+          icon="blueprint">
           <span t="item.blueprint"></span>
         </button-secondary>
 
@@ -53,6 +59,6 @@
         </button-secondary>
 
       </aside>
-      <div>
+    </div>
   </main>
 </template>

--- a/client/src/pages/item-overview.js
+++ b/client/src/pages/item-overview.js
@@ -43,6 +43,10 @@ export class ItemOverview {
     this.user = user;
   }
 
+  async activate() {
+    this.uiBehaviorConfig = this.qConfig.get('uiBehavior');
+  }
+
   async attached() {
     this.isToolAvailable = await this.toolsInfo.isToolWithNameAvailable(
       this.item.conf.tool

--- a/client/src/resources/QConfig.js
+++ b/client/src/resources/QConfig.js
@@ -1,9 +1,21 @@
+import { inject } from "aurelia-framework";
 import qEnv from "resources/qEnv.js";
+import User from "resources/User.js";
+import { HttpClient } from "aurelia-fetch-client";
 
+@inject(User, HttpClient)
 export default class QConfig {
-  constructor() {
-    this.configLoaded = qEnv.QServerBaseUrl.then(QServerBaseUrl => {
-      return fetch(`${QServerBaseUrl}/editor/config`);
+  constructor(user, httpClient) {
+    this.httpClient = httpClient;
+    this.configLoaded = new Promise(resolve => {
+      this.resolveConfigLoaded = resolve;
+    });
+    user.loaded.then(() => {
+      return qEnv.QServerBaseUrl.then(QServerBaseUrl => {
+        return this.httpClient.fetch(`${QServerBaseUrl}/editor/config`, {
+          credentials: 'include'
+        });
+      });
     })
       .then(response => {
         if (response.ok) {
@@ -13,6 +25,7 @@ export default class QConfig {
       })
       .then(config => {
         this.config = config;
+        this.resolveConfigLoaded();
       })
       .catch(e => {
         this.config = null;

--- a/client/src/resources/Statistics.js
+++ b/client/src/resources/Statistics.js
@@ -2,23 +2,19 @@ import qEnv from "resources/qEnv.js";
 
 export default class Statistics {
   async getNumberOfActiveItems(inLastDaysCount = undefined) {
-    try {
-      const QServerBaseUrl = await qEnv.QServerBaseUrl;
+    const QServerBaseUrl = await qEnv.QServerBaseUrl;
 
-      let url = `${QServerBaseUrl}/statistics/number-of-items`;
-      if (inLastDaysCount) {
-        url += `/${Date.now() - inLastDaysCount * 24 * 60 * 60 * 1000}`;
-      }
-
-      const response = await fetch(url);
-      if (!response.ok) {
-        throw response;
-      }
-
-      const data = await response.json();
-      return data.value;
-    } catch (e) {
-      return null;
+    let url = `${QServerBaseUrl}/statistics/number-of-items`;
+    if (inLastDaysCount) {
+      url += `/${Date.now() - inLastDaysCount * 24 * 60 * 60 * 1000}`;
     }
+
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw response;
+    }
+
+    const data = await response.json();
+    return data.value;
   }
 }

--- a/routes/basePath.js
+++ b/routes/basePath.js
@@ -1,0 +1,1 @@
+module.exports = process.env.ENVIRONMENT === 'local' ? './client' : './client/export';

--- a/routes/default.js
+++ b/routes/default.js
@@ -1,3 +1,4 @@
+const basePath = require('./basePath.js')
 module.exports = {
   method: "GET",
   path: "/{path*}",
@@ -9,7 +10,7 @@ module.exports = {
   },
   handler: {
     directory: {
-      path: "./client/export",
+      path: basePath,
       redirectToSlash: true
     }
   }

--- a/routes/index.js
+++ b/routes/index.js
@@ -13,7 +13,7 @@ module.exports = (config) => {
   });
 
   const compiledIndexFileContent = indexFile
-    .replace(/<base.*\n/, `<base href="${config.basePath || '/'}">\n`)
+    .replace(/^\s*<base([^>]*)>/, `<base href="${config.basePath || '/'}">\n`)
     .replace("<!-- HEAD_MARKUP -->", env.headMarkup)
     .replace("<!-- BODY_START_MARKUP -->", env.bodyStartMarkup)
     .replace("<!-- BODY_END_MARKUP -->", env.bodyEndMarkup);

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const basePath = require('./basePath.js')
 
 module.exports = (config) => {
   const env = {
@@ -7,7 +8,7 @@ module.exports = (config) => {
     bodyEndMarkup: process.env.BODY_END_MARKUP || ""
   };
 
-  const indexFile = fs.readFileSync("./client/export/index.html", {
+  const indexFile = fs.readFileSync(`${basePath}/index.html`, {
     encoding: "utf-8"
   });
 

--- a/routes/jspm_packages.js
+++ b/routes/jspm_packages.js
@@ -1,3 +1,4 @@
+const basePath = require('./basePath.js')
 module.exports = [
   {
     method: 'GET',
@@ -10,7 +11,7 @@ module.exports = [
     },
     handler: {
       directory: {
-        path: './client/export/jspm_packages/npm',
+        path: `${basePath}/jspm_packages/npm`,
         redirectToSlash: true,
         index: true
       }
@@ -27,7 +28,7 @@ module.exports = [
     },
     handler: {
       directory: {
-        path: './client/export/jspm_packages/github',
+        path: `${basePath}/jspm_packages/github`,
         redirectToSlash: true,
         index: true
       }
@@ -38,7 +39,7 @@ module.exports = [
     path: '/jspm_packages/{path*}',
     handler: {
       directory: {
-        path: './client/export/jspm_packages',
+        path: `${basePath}/jspm_packages`,
         redirectToSlash: true,
         index: true
       }
@@ -48,7 +49,7 @@ module.exports = [
     method: 'GET',
     path: '/config.js',
     handler: {
-      file: './client/export/config.js'
+      file: `${basePath}/config.js`
     }
   }
 ]


### PR DESCRIPTION
Relations:
  - Issue: https://github.com/livingdocsIO/livingdocs-planning/issues/3172
  - Related PRs: https://github.com/livingdocsIO/Q/pull/2

## Description
Improves several things in Q editor to work better for the bluewin Q setup.


## Changelog

#### Dev Setup

- wire the basePath config through so `cd client && gulp watch` (starting the integrated dev server) work with the complete dev setup (tools and server and bluewin-editor proxy)

#### Config

- loads the User before any config and translations and sends the `Authorization` header to the config fetching requests allowing the config to depend on the logged in user

#### UI Config

- new option to disable to user name in the item list and item overview page
- new option to hide the user menu when it's not needed

#### Preview

- add new previewSizes options:
  - `value: 'auto'` resulting in the preview taking up the available space
  - `scaleToFit: true`: applies a scale factor to the preview container to scale a graphic up or down to fit into the preview container (it measures the actual with of the outermost element of the graphic to calculate the scaling factor, the graphic style/layout code is responsible to make sure the outermost element contains the whole graphic without any overflow)