### PR TITLE
fix(base-path): fix base path replacement in index.html file

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -13,7 +13,7 @@ module.exports = (config) => {
   });
 
   const compiledIndexFileContent = indexFile
-    .replace(/^\s*<base([^>]*)>/, `<base href="${config.basePath || '/'}">\n`)
+    .replace(/\s*<base([^>]*)>/, `\n<base href="${config.basePath || '/'}">\n`)
     .replace("<!-- HEAD_MARKUP -->", env.headMarkup)
     .replace("<!-- BODY_START_MARKUP -->", env.bodyStartMarkup)
     .replace("<!-- BODY_END_MARKUP -->", env.bodyEndMarkup);


### PR DESCRIPTION
## Description
- Fixes the regex to replace the basePath even if the `<base>` is not defined at the beginning of the string (which it is not)