### PR TITLE
Pointer in dynamic schema

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,12 +5,16 @@ name: build-q-editor
 steps:
 - name: install
   image: node:9-alpine
+  environment:
+    GH_TOKEN:
+      from_secret: GH_TOKEN
   commands:
     - |
       apk add --no-cache git
       npm install
       cd client
       npm install
+      node_modules/.bin/jspm config registries.github.auth $GH_TOKEN
       node_modules/.bin/jspm install
       node_modules/.bin/gulp export
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -109,6 +109,6 @@ trigger:
   event: [tag]
 ---
 kind: signature
-hmac: 152b671dab048e7bab5b0b6f45ad6d72099cd2769f036021d5b0864fbd890896
+hmac: 4000c0cf45400a23d8afb5f44a30ab092521ec7e7b2638da0c8b064d7217a3fd
 
 ...

--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ There are three types of availability-checks:
 
 Dynamic Schema allows you to alter the schema for a specific property based on dynamic data. This is for example used in the charts tool to change the maxItems of an array based on the data
 
+##### Using config.fields
+An object `item` is sent to the endpoint containing the complete structure but only the fields defined in `fields`
 ```json
 "highlightDataSeries": {
   "title": "Hervorhebungen von Datenreihen",
@@ -296,6 +298,25 @@ Dynamic Schema allows you to alter the schema for a specific property based on d
       "config": {
         "endpoint": "dynamic-schema/highlighDataSeries",
         "fields": ["data"]
+      }
+    }
+  }
+}
+```
+
+##### Using config.pointer / config.pointers
+The endpoint receives an object `data` in the payload that contains the data at the specifiec json pointer. Basic relativ pointers are supported to work with arrays. See: https://tools.ietf.org/id/draft-handrews-relative-json-pointer-00.html
+Use `config.pointers` as an array if you need it. `data` in payload will be an array in the same order as specified in the schema.
+```json
+"highlightDataSeries": {
+  "title": "Hervorhebungen von Datenreihen",
+  "type": "array",
+  "Q:options": {
+    "dynamicSchema": {
+      "type": "ToolEndpoint",
+      "config": {
+        "endpoint": "dynamic-schema/highlighDataSeries",
+        "pointer": "/some/json/pointer"
       }
     }
   }

--- a/client/config.js
+++ b/client/config.js
@@ -6,6 +6,7 @@ System.config({
     "github:*": "jspm_packages/github/*",
     "npm:*": "jspm_packages/npm/*"
   },
+
   map: {
     "ajv": "npm:ajv@5.5.2",
     "array2d": "npm:array2d@0.0.5",
@@ -49,6 +50,7 @@ System.config({
     "i18next": "npm:i18next@9.1.0",
     "i18next-fetch-backend": "npm:i18next-fetch-backend@0.0.1",
     "i18next-xhr-backend": "npm:i18next-xhr-backend@3.2.2",
+    "jsonpointer": "npm:jsonpointer@4.0.1",
     "leaflet": "github:Leaflet/Leaflet@1.3.1",
     "leaflet-geocoder-mapzen": "npm:leaflet-geocoder-mapzen@1.8.0",
     "leaflet-search": "npm:leaflet-search@2.3.7",
@@ -591,7 +593,7 @@ System.config({
       "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "core-util-is": "npm:core-util-is@1.0.2",
       "events": "github:jspm/nodelibs-events@0.1.1",
-      "inherits": "npm:inherits@2.0.4",
+      "inherits": "npm:inherits@2.0.1",
       "isarray": "npm:isarray@0.0.1",
       "process": "github:jspm/nodelibs-process@0.1.2",
       "stream-browserify": "npm:stream-browserify@1.0.0",
@@ -620,7 +622,7 @@ System.config({
     },
     "npm:stream-browserify@1.0.0": {
       "events": "github:jspm/nodelibs-events@0.1.1",
-      "inherits": "npm:inherits@2.0.4",
+      "inherits": "npm:inherits@2.0.1",
       "readable-stream": "npm:readable-stream@1.1.14"
     },
     "npm:string_decoder@0.10.31": {

--- a/client/package.json
+++ b/client/package.json
@@ -78,6 +78,7 @@
       "i18next": "npm:i18next@9",
       "i18next-fetch-backend": "npm:i18next-fetch-backend@^0.0.1",
       "i18next-xhr-backend": "npm:i18next-xhr-backend@^3.2.2",
+      "jsonpointer": "npm:jsonpointer@^4.0.1",
       "leaflet": "github:Leaflet/Leaflet@1.3.1",
       "leaflet-geocoder-mapzen": "npm:leaflet-geocoder-mapzen@1.8.0",
       "leaflet-search": "npm:leaflet-search@2.3.7",

--- a/client/src/elements/schema-editor/schema-editor-array.css
+++ b/client/src/elements/schema-editor/schema-editor-array.css
@@ -30,6 +30,7 @@ schema-editor-array {
   margin-left: var(--q-space-base);
   margin-top: auto;
   margin-bottom: auto;
+  width: auto;
 }
 
 .schema-editor-array__entry-container--expandable

--- a/client/src/elements/schema-editor/schema-editor-array.html
+++ b/client/src/elements/schema-editor/schema-editor-array.html
@@ -112,6 +112,7 @@
         no-object-title="true"
         notifications.bind="notifications"
         show-notifications.bind="showNotifications"
+        pointer.one-way="getPointer($index)"
       >
       </schema-editor-wrapper>
     </div>

--- a/client/src/elements/schema-editor/schema-editor-array.js
+++ b/client/src/elements/schema-editor/schema-editor-array.js
@@ -12,6 +12,7 @@ export class SchemaEditorArray {
   @bindable change;
   @bindable notifications;
   @bindable showNotifications;
+  @bindable pointer;
 
   arrayEntryOptions = [];
 
@@ -33,6 +34,10 @@ export class SchemaEditorArray {
         this.change();
       }
     };
+  }
+
+  getPointer(index) {
+    return `${this.pointer}/${index}`;
   }
 
   dataChanged() {

--- a/client/src/elements/schema-editor/schema-editor-object.html
+++ b/client/src/elements/schema-editor/schema-editor-object.html
@@ -34,6 +34,7 @@
     >
       <schema-editor-wrapper
         if.bind="!$parent.schema.properties[propertyName]['Q:options'] || !$parent.schema.properties[propertyName]['Q:options'].hideInEditor"
+        pointer.one-way="getPointer(propertyName)"
         schema.bind="$parent.schema.properties[propertyName]"
         data.two-way="$parent.data[propertyName]"
         change.bind="$parent.change"
@@ -46,6 +47,7 @@
 
     <schema-editor-wrapper
       if.bind="(collapsedState === 'expanded' || !options.expandable) && (!$parent.schema.properties[propertyName]['Q:options'] || !$parent.schema.properties[propertyName]['Q:options'].hideInEditor) && getType($parent.schema.properties[propertyName]) !== 'object' && getType($parent.schema.properties[propertyName]) !== 'array'"
+      pointer.one-way="getPointer(propertyName)"
       schema.bind="$parent.schema.properties[propertyName]"
       data.two-way="$parent.data[propertyName]"
       change.bind="$parent.change"

--- a/client/src/elements/schema-editor/schema-editor-object.html
+++ b/client/src/elements/schema-editor/schema-editor-object.html
@@ -26,7 +26,7 @@
 
   <div
     if.bind="schema.properties"
-    repeat.for="propertyName of schema.properties | keys"
+    repeat.for="propertyName of schema.properties | keys | filter: {remove: '__observers__'}"
   >
     <fieldset
       if.bind="(collapsedState === 'expanded' || !options.expandable) && (getType($parent.schema.properties[propertyName]) === 'object' || getType($parent.schema.properties[propertyName]) === 'array')"

--- a/client/src/elements/schema-editor/schema-editor-object.js
+++ b/client/src/elements/schema-editor/schema-editor-object.js
@@ -14,6 +14,8 @@ export class SchemaEditorObject {
   notifications;
   @bindable
   showNotifications;
+  @bindable
+  pointer;
 
   options = {
     expandable: false
@@ -35,6 +37,13 @@ export class SchemaEditorObject {
       this.data = {};
     }
     this.applyOptions();
+  }
+
+  getPointer(propertyName) {
+    if (this.pointer) {
+      return `${this.pointer}/${propertyName}`;
+    }
+    return `/${propertyName}`;
   }
 
   schemaChanged() {

--- a/client/src/elements/schema-editor/schema-editor-wrapper.html
+++ b/client/src/elements/schema-editor/schema-editor-wrapper.html
@@ -2,7 +2,8 @@
   <require from="./schema-editor-wrapper.css"></require>
   <div if.bind="getType(schema) === 'object'" class="schema-editor-block">
     <require from="./schema-editor-object"></require>
-    <schema-editor-object
+    <schema-editor-object\
+      pointer.one-way="pointer"
       schema.bind="schema"
       data.two-way="data"
       change.bind="change"
@@ -121,6 +122,7 @@
   <div if.bind="getType(schema) === 'array'" class="schema-editor-block">
     <require from="./schema-editor-array"></require>
     <schema-editor-array
+      pointer.one-way="pointer"
       schema.bind="schema"
       data.two-way="data"
       change.bind="change"

--- a/client/src/elements/schema-editor/schema-editor-wrapper.html
+++ b/client/src/elements/schema-editor/schema-editor-wrapper.html
@@ -2,7 +2,7 @@
   <require from="./schema-editor-wrapper.css"></require>
   <div if.bind="getType(schema) === 'object'" class="schema-editor-block">
     <require from="./schema-editor-object"></require>
-    <schema-editor-object\
+    <schema-editor-object
       pointer.one-way="pointer"
       schema.bind="schema"
       data.two-way="data"

--- a/client/src/elements/schema-editor/schema-editor-wrapper.js
+++ b/client/src/elements/schema-editor/schema-editor-wrapper.js
@@ -11,6 +11,8 @@ const log = LogManager.getLogger("Q");
 @inject(NotificationChecker, AvailabilityChecker, ToolEndpointChecker, Element)
 export class SchemaEditorWrapper {
   @bindable
+  pointer;
+  @bindable
   schema;
   @bindable
   data;

--- a/client/src/elements/schema-editor/schema-editor-wrapper.js
+++ b/client/src/elements/schema-editor/schema-editor-wrapper.js
@@ -163,7 +163,7 @@ export class SchemaEditorWrapper {
 
   async getDynamicSchema(dynamicSchema) {
     try {
-      return await this.toolEndpointChecker.check(dynamicSchema.config);
+      return await this.toolEndpointChecker.check(dynamicSchema.config, this.pointer);
     } catch (e) {
       throw new Error(
         `failed to get dynamicSchema for ${JSON.stringify(dynamicSchema)} ${e}`

--- a/client/src/resources/CurrentItemProvider.js
+++ b/client/src/resources/CurrentItemProvider.js
@@ -24,7 +24,6 @@ export default class CurrentItemProvider {
   }
 
   getDataByPointer(pointer) {
-    const ptr = jsonPointer.compile(pointer);
-    return ptr.get(this.item.conf);
+    return jsonPointer.get(this.item.conf, pointer);
   }
 }

--- a/client/src/resources/CurrentItemProvider.js
+++ b/client/src/resources/CurrentItemProvider.js
@@ -1,5 +1,6 @@
 import get from "get-value";
 import set from "set-value";
+import jsonPointer from 'jsonpointer';
 
 export default class CurrentItemProvider {
   setCurrentItem(item) {
@@ -20,5 +21,10 @@ export default class CurrentItemProvider {
       set(item, field, get(this.item.conf, field));
     }
     return item;
+  }
+
+  getDataByPointer(pointer) {
+    const ptr = jsonPointer.compile(pointer);
+    return ptr.get(this.item.conf);
   }
 }

--- a/client/src/value-converters/FilterValueConverter.js
+++ b/client/src/value-converters/FilterValueConverter.js
@@ -1,0 +1,9 @@
+import { valueConverter } from "aurelia-framework";
+
+@valueConverter("filter")
+export class FilterValueConverter {
+  toView(arr, config) {
+    const stringsToRemove = config.remove.trim().split(',');
+    return arr.filter(str => !stringsToRemove.includes(str));
+  }
+}

--- a/client/src/value-converters/index.js
+++ b/client/src/value-converters/index.js
@@ -1,5 +1,6 @@
 export function configure(frameworkConfiguration) {
   frameworkConfiguration
+    .globalResources("./FilterValueConverter.js")
     .globalResources("./ForceNumberValueConverter.js")
     .globalResources("./JsonValueConverter.js")
     .globalResources("./KeysValueConverter.js")


### PR DESCRIPTION
### Description
- `dynamicSchema.config.pointer` /  `dynamicSchema.config.pointers` can be used to specify the data to be sent to dynamicSchema ToolEndpoints.
- Basic relative json pointers (https://tools.ietf.org/id/draft-handrews-relative-json-pointer-00.html) are supported to send the current array item for example using the pointer `1`.

See https://github.com/livingdocsIO/Q/commit/9cbae87965e188636a5508b01beb64c0ec3fc02b as usage example.