### PR TITLE
Schema editor files improvements

### DIFF
--- a/client/src/elements/schema-editor/schema-editor-files.html
+++ b/client/src/elements/schema-editor/schema-editor-files.html
@@ -1,6 +1,9 @@
 <template class="schema-editor-input ${showNotifications ? 'schema-editor-input--with-notifications' : ''}">
   <require from="./schema-editor-files.css"></require>
   <div>
+    <label>
+      ${schema["title"] & toolT}
+    </label>
     <div class="dropzone" ref="dropzoneElement"></div>
   </div>
 </template>

--- a/client/src/elements/schema-editor/schema-editor-files.js
+++ b/client/src/elements/schema-editor/schema-editor-files.js
@@ -7,15 +7,6 @@ import QConfig from "resources/QConfig";
 import { AuthService } from "aurelia-authentication";
 const log = LogManager.getLogger("Q");
 
-function blobToDataURL(blob) {
-  return new Promise((resolve, reject) => {
-    let reader = new FileReader();
-    reader.onerror = reject;
-    reader.onload = (e) => resolve(reader.result);
-    reader.readAsDataURL(blob);
-  });
-}
-
 @inject(Loader, AuthService, Notification, I18N, QConfig, HttpClient)
 export class SchemaEditorFiles {
   @bindable
@@ -214,7 +205,7 @@ export class SchemaEditorFiles {
           if (!response.ok || response.status >= 400) {
             return;
           }
-          mockFile.dataURL =  await blobToDataURL(await response.blob()); // needed for dropzone to create the thumbnail in a canvas
+          mockFile.dataURL =  URL.createObjectURL(await response.blob()); // needed for dropzone to create the thumbnail in a canvas
           this.dropzone.createThumbnailFromUrl(
             mockFile,
             this.dropzoneOptions.thumbnailWidth,

--- a/client/src/elements/schema-editor/schema-editor-files.js
+++ b/client/src/elements/schema-editor/schema-editor-files.js
@@ -202,7 +202,7 @@ export class SchemaEditorFiles {
         if (file.type && file.type.includes("image/")) {
           const imageUrl = fileBaseUrl ? `${fileBaseUrl}/${file.key}` : file.url;
           const response = await this.httpClient.fetch(imageUrl);
-          if (!response.ok || response.status >= 400) {
+          if (!response.ok) {
             return;
           }
           mockFile.dataURL =  URL.createObjectURL(await response.blob()); // needed for dropzone to create the thumbnail in a canvas


### PR DESCRIPTION
# Description

## Thumbnail preview in Dropzone
With this code the thumbnail preview in the schema-editor dropzones for existing items with images gets loaded via `fileRequestBaseUrl` configured in `schemaEditor.files.fileRequestBaseUrl.host` and `schemaEditor.files.fileRequestBaseUrl.path` within the editor config.
It follows the same config schema as the Q-server file plugin.

The files are requested through `aurelia-fetch-client` (that is configured to do authenticated requests) to send credentials to the endpoint configured in `fileRequestBaseUrl`.

## Label
The schema objects title gets displayed on top of the dropzone element as a label now.