### PR TITLE
fix(dynamic schema): clone schema objects before usage in arrays

### DIFF
--- a/client/src/elements/schema-editor/schema-editor-array.js
+++ b/client/src/elements/schema-editor/schema-editor-array.js
@@ -48,7 +48,7 @@ export class SchemaEditorArray {
     // on all changes. For addElement we already know the schema beforehand e.g.
     if (Array.isArray(this.data)) {
       this.dataItemsSchemas = this.data.map(item => {
-        return this.getSchemaForData(item);
+        return JSON.parse(JSON.stringify(this.getSchemaForData(item)));
       });
     }
 
@@ -85,7 +85,7 @@ export class SchemaEditorArray {
     }
     const entry = this.objectFromSchemaGenerator.generateFromSchema(schema);
 
-    this.dataItemsSchemas.push(schema);
+    this.dataItemsSchemas.push(JSON.parse(JSON.stringify(schema)));
     this.data.push(entry);
 
     this.expand(this.data.indexOf(entry));


### PR DESCRIPTION
## Description

Issue: https://github.com/livingdocsIO/livingdocs-planning/issues/3394

We need to clone the schema object before passing it to `schema-editor-wrapper` for the single array items. Otherwise dynamic schema using the ability to send different data using the json-pointer feature thus resulting in different dynamic schema applied overwrites schema objects from other array items with wrong data.

the bug was present before the introduction of the json pointer feature, but was never visible since different array items based on the same schema could never have different dynamic schema applied.